### PR TITLE
Edit chat cl

### DIFF
--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -2,13 +2,21 @@ import React from "react"
 import "./Messages.css"
 import {Link} from "react-router-dom"
 
-export const MessageCard = ({ message, userName }) => (
+import { MessageList } from "./MessageList"
+
+export const MessageCard = ({ message, userName, id, changeParentState }) => (
     
     <>
         <div className="container-card container card  rounded ">
             <div className='row '>
                 <div className='name col-1  text-nowrap'><h6 className=' fw-bolder'>{userName}</h6></div>
                 <div className='col-2 ><small class = text-muted'>{message.time}</div>
+                <div className='col-2 ><small class = text-muted'>{id}</div>
+                <button 
+                        onClick={changeParentState}
+                        >
+                        Edit
+                </button>
             </div>
             <div >
                 <div >{message.message}</div>

--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -8,20 +8,16 @@ export const MessageCard = ({ message, userName, id, changeParentState, userId, 
     return (
     <>
         <div className="container-card container card  rounded ">
-            <div className='row '>
-                <div className='name col-1  text-nowrap'><h6 className=' fw-bolder'>{userName}</h6></div>
-                <div className='col-2 ><small class = text-muted'>{message.time}</div>
-                <div className='col-2 ><small class = text-muted'>{id}</div>
-                {userId === currentUser ? (
-        <button 
-                        
-        onClick={changeParentState}
-        >
-        Edit
-        </button> 
-      ) : (
-        ""
-      )}
+            <div className='row fluid'>
+                
+                <div className='col-lg fw-bolder'>{userName}</div>
+                <div className='col-lg  text-nowrap><small class = text-muted'>{message.time}</div>
+                <div className='col-lg  text-nowrap><small class = text-muted'>{id}</div>
+                    {userId === currentUser ? (
+                        <button onClick={changeParentState}>Edit</button> 
+                        ) : (
+                        ""
+                        )}
                 
             </div>
             <div >

--- a/src/components/messages/MessageCard.js
+++ b/src/components/messages/MessageCard.js
@@ -4,26 +4,33 @@ import {Link} from "react-router-dom"
 
 import { MessageList } from "./MessageList"
 
-export const MessageCard = ({ message, userName, id, changeParentState }) => (
-    
+export const MessageCard = ({ message, userName, id, changeParentState, userId, currentUser }) => {
+    return (
     <>
         <div className="container-card container card  rounded ">
             <div className='row '>
                 <div className='name col-1  text-nowrap'><h6 className=' fw-bolder'>{userName}</h6></div>
                 <div className='col-2 ><small class = text-muted'>{message.time}</div>
                 <div className='col-2 ><small class = text-muted'>{id}</div>
-                <button 
-                        onClick={changeParentState}
-                        >
-                        Edit
-                </button>
+                {userId === currentUser ? (
+        <button 
+                        
+        onClick={changeParentState}
+        >
+        Edit
+        </button> 
+      ) : (
+        ""
+      )}
+                
             </div>
             <div >
                 <div >{message.message}</div>
             </div>
         </div>     
-    </>       
-)
+    </>   
+    )    
+}
 
 
  

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -61,7 +61,7 @@ export const MessageList = () => {
     //a messaages edit button is clicked 
     const handleClickEditMessage = (id) =>{
       setEditId(id)
-      editedMessage.value = 'plwAS';
+      
       
     }
     const handleClickCancelEdit = () =>{

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -7,48 +7,84 @@ import { Container,Row, Col } from 'react-bootstrap'
 
 
 //MessageList is exported and called at appviews when route is /Messages. 
+//component, not functions, consists of user interface includes jsx
 export const MessageList = () => {
     //Bringing these in at MessageContext.Provider on the provider file
-  const { messages, getMessages, addMessage } = useContext(MessageContext)
+  const { messagesFromProvider, getMessages, addMessage, updateMessage } = useContext(MessageContext)
   const fieldRef = useRef(null);
   
 
   //this is independant (not afiliated with messages variable in provider)
-  const [message, setMessage] = useState({message:""})
+  //here is where you add things to state, which means you can track its changes in the reactdev.Upon creation its set to empty object
+  const [message, setMessage] = useState({message:''})
+  //set editId to state. 
+  const [editId, setEditId] = useState(0)
+  const [editedMessage, setEditedMessage] = useState({message:''})
+  
+  
     //isLoading is nothing but a boolean. setIsLoading is a fx or method that is assigned to adjust isLoading as needed
     //const [isLoading, setIsLoading] = useState(true)
+    const handleEdits=(event)=>{
+      const edit = {...editedMessage}
+      edit[event.target.id]= event.target.value
+      setEditedMessage(edit)
+      console.log(editedMessage.editor)
+    }
   
-    const handleControlledInputChange = (event) => {
-    /* When changing a state object or array,
-    always create a copy, make changes, and then set state.*/
+    const handleMessageInputControlledChanges = (event) => {
+    //create a copy of the object that was created when state was initialized. Name it whatever, its a copy now
     const newMessage = { ...message }
-    /* Animal is an object with properties.
-    Set the property to the new value
-    using object bracket notation. */
     newMessage[event.target.id] = event.target.value
-    // update state
     setMessage(newMessage)
+    ;
+    // update state
+    
   }
+  
   
 
   const handleClickSaveMessage = (event) => {
-      console.log(localStorage.getItem('nutshell_user'));
+    
       addMessage({
         message:message.message,
         userId:localStorage.getItem('nutshell_user'),
         time:new Date().toLocaleTimeString()
     }).then(() => {
         fieldRef.current.scrollIntoView();
-        setMessage({message:""})
+        setMessage({message:" "})
+        
+        
         // expected output: "Success!"
       });
     }
+
+    //a messaages edit button is clicked 
+    const handleClickEditMessage = (id) =>{
+      setEditId(id)
+      
+    }
+    const handleClickCancelEdit = () =>{
+      setEditId(0)
+    }
+    const handleClickSaveChanges = ()=>{
+      
+      updateMessage({
+        id:editId,
+        message:editedMessage.message,
+        userId:localStorage.getItem('nutshell_user'),
+        time:new Date().toLocaleTimeString()
+      }).then(() => {
+        setEditId(0)
+        
+      })
+    }
+
 
   // Empty dependency array - useEffect only runs after first render, will not run the 2nd time because of the empty dependancy array
   useEffect(() => {
       getMessages()
       fieldRef.current.scrollIntoView()
-  }, [])
+  },[])
   
   return (
       
@@ -58,17 +94,44 @@ export const MessageList = () => {
             <div className="messages-container">
         
                     {
-                    messages.map(messageInLoop => {
-                        return <MessageCard key={messageInLoop.id}
-                            message={messageInLoop}
-                            userName= {messageInLoop.user.name} />
-                    })
+                      //getMessages has been called from useEffect we now itereate through messages from the fetch call
+                      //if editId, which is in state and set originally to 0, now matches that of a fetch calls message.id
+                      //bring up the text edit form referenced by editTextAreaId.
+                    messagesFromProvider.map(messageInLoop => {
+                      return  (editId===messageInLoop.id)
+                      //if 
+                      ?   <Container fluid >
+                        <div className="edit-group ">
+                      <textarea type="text" id="message"  required autoFocus className="edit-form-control" onChange={handleEdits} defaultValue = {message.message} /> 
+                          <button 
+                              onClick={event => {event.preventDefault()
+                                handleClickSaveChanges(messageInLoop.id)
+                              }}>
+                              Save Changes
+                          </button>
+                          <button 
+                              onClick={event => {event.preventDefault()
+                                handleClickCancelEdit()
+                              }}>
+                              Cancel
+                          </button>
+                      </div>
+                  </Container> 
+
+
+                          // if the editId, which is in State which we originally set equal to 0, is still 0 (doesnt match any messages'id), then send these to the messageCard component. message is the message, user name, changeParentState is an anonymous function. Send it to componenet card because that is where its childEvent (button is). Send the function there, to be available if clicked. Carefull not to create infinite loop, mnust be anon fx
+                      :  <MessageCard key={messageInLoop.id}
+                            message= {messageInLoop}
+                            userName= {messageInLoop.user.name}
+                            changeParentState= {()=>handleClickEditMessage(messageInLoop.id)} />
+                  })
                     }
+                    {/* //fake div created to use auto scroll effect */}
                     <div className="dummy" ref={fieldRef}>
             </div>
             <Container fluid >
                 <div className="input-group">
-                <textarea type="text" id="message" value={message.message} required autoFocus className="form-control" onChange={handleControlledInputChange}placeholder="message.." /> 
+                <textarea type="text" id="message"  required autoFocus className="form-control" onChange={handleMessageInputControlledChanges} value={message.message} placeholder="message.." /> 
                 <button 
                         onClick={event => {event.preventDefault()
                         handleClickSaveMessage()

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -102,9 +102,9 @@ export const MessageList = () => {
                       console.log(messageInLoop.userId, localStorage.getItem('nutshell_user'));
                       return  (editId===messageInLoop.id)
                       //if 
-                      ?   <Container fluid >
+                  ?   <Container fluid >
                         <div className="edit-group ">
-                      <textarea type="text" id="message"  required autoFocus className="edit-form-control" onChange={handleEdits} defaultValue = {messageInLoop.message} /> 
+                        <textarea type="text" id="message"  required autoFocus className="edit-form-control" onChange={handleEdits} defaultValue = {messageInLoop.message} /> 
                           <button 
                               onClick={event => {event.preventDefault()
                                 handleClickSaveChanges(messageInLoop.id)
@@ -117,8 +117,8 @@ export const MessageList = () => {
                               }}>
                               Cancel
                           </button>
-                      </div>
-                  </Container> 
+                        </div>
+                      </Container> 
 
 
                           // if the editId, which is in State which we originally set equal to 0, is still 0 (doesnt match any messages'id), then send these to the messageCard component. message is the message, user name, changeParentState is an anonymous function. Send it to componenet card because that is where its childEvent (button is). Send the function there, to be available if clicked. Carefull not to create infinite loop, mnust be anon fx

--- a/src/components/messages/MessageList.js
+++ b/src/components/messages/MessageList.js
@@ -28,7 +28,7 @@ export const MessageList = () => {
       const edit = {...editedMessage}
       edit[event.target.id]= event.target.value
       setEditedMessage(edit)
-      console.log(editedMessage.editor)
+      console.log(editedMessage.message)
     }
   
     const handleMessageInputControlledChanges = (event) => {
@@ -61,6 +61,7 @@ export const MessageList = () => {
     //a messaages edit button is clicked 
     const handleClickEditMessage = (id) =>{
       setEditId(id)
+      editedMessage.value = 'plwAS';
       
     }
     const handleClickCancelEdit = () =>{
@@ -98,11 +99,12 @@ export const MessageList = () => {
                       //if editId, which is in state and set originally to 0, now matches that of a fetch calls message.id
                       //bring up the text edit form referenced by editTextAreaId.
                     messagesFromProvider.map(messageInLoop => {
+                      console.log(messageInLoop.userId, localStorage.getItem('nutshell_user'));
                       return  (editId===messageInLoop.id)
                       //if 
                       ?   <Container fluid >
                         <div className="edit-group ">
-                      <textarea type="text" id="message"  required autoFocus className="edit-form-control" onChange={handleEdits} defaultValue = {message.message} /> 
+                      <textarea type="text" id="message"  required autoFocus className="edit-form-control" onChange={handleEdits} defaultValue = {messageInLoop.message} /> 
                           <button 
                               onClick={event => {event.preventDefault()
                                 handleClickSaveChanges(messageInLoop.id)
@@ -123,6 +125,8 @@ export const MessageList = () => {
                       :  <MessageCard key={messageInLoop.id}
                             message= {messageInLoop}
                             userName= {messageInLoop.user.name}
+                            userId={messageInLoop.userId}
+                            currentUser={localStorage.getItem('nutshell_user')}
                             changeParentState= {()=>handleClickEditMessage(messageInLoop.id)} />
                   })
                     }

--- a/src/components/messages/MessageProvider.js
+++ b/src/components/messages/MessageProvider.js
@@ -7,7 +7,7 @@ export const MessageContext = createContext()
 // This component establishes what data can be used.This function is called on the appviews file whenver the route is /animals
 export const MessageProvider = (props) => {
     //statefunction
-    const [messages, setMessages] = useState([])
+    const [messagesFromProvider, setMessages] = useState([])
     //new magic state. tracking searchTerms, set to empty string right now. We need to export setSearchTerms below. We generally have not exported setters, setAnimals for instance, becuase it is called everytime we use getAnimals
     
 
@@ -43,7 +43,8 @@ export const MessageProvider = (props) => {
     // }
 
     const updateMessage = messageObject => {
-        return fetch(`http://localhost:8088/messages/${messages.id}`, {
+        console.log(messageObject);
+        return fetch(`http://localhost:8088/messages/${messageObject.id}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json"
@@ -61,7 +62,7 @@ export const MessageProvider = (props) => {
     */
     return (
         <MessageContext.Provider value={{
-            messages, getMessages, addMessage, updateMessage, 
+            messagesFromProvider, getMessages, addMessage, updateMessage, 
         }}>
             {props.children}
         </MessageContext.Provider>

--- a/src/components/messages/Messages.css
+++ b/src/components/messages/Messages.css
@@ -1,11 +1,18 @@
+*{
+    margin:0;
+    padding:0;
+}
 
-
+.messages-div{
+    width: 3000px;
+}
 .messages-container{
     height: 80vh;
     overflow: auto;
-    
-     
+    width: 3000px;
+
 }
+
 
 .input-group{
     position: absolute;
@@ -15,10 +22,11 @@
 }
 
 .container-card{
-    width:100vw;
+    width:3000rem;
+    margin:10px;
 }
 
 .edit-group{
-    width:958px;
+    width:3000px;
 
 }

--- a/src/components/messages/Messages.css
+++ b/src/components/messages/Messages.css
@@ -3,6 +3,7 @@
 .messages-container{
     height: 80vh;
     overflow: auto;
+    
      
 }
 
@@ -15,4 +16,9 @@
 
 .container-card{
     width:100vw;
+}
+
+.edit-group{
+    width:958px;
+
 }


### PR DESCRIPTION
## What? Update enables user to edit messages that they have sent
## Why? MVP
## How? As chats are printed, checks for edit state on each message. If message is in edit state, inline edit form is rendered. User can only edit chats that they sent but are able to see all chats
## Testing? Create messages from 2 different accounts, check what edit caps are available for each account
